### PR TITLE
correct instance for bridge source

### DIFF
--- a/src/main/java/com/gss/ch03/job/Bridge.java
+++ b/src/main/java/com/gss/ch03/job/Bridge.java
@@ -20,7 +20,7 @@ class Bridge extends Source {
 
   @Override
   public void setupInstance(int instance) {
-    instance = instance;
+    this.instance = instance;
     reader = setupSocketReader(portBase + instance);
   }
 


### PR DESCRIPTION
Before the `instance` variable was assigned to itself.  Now it is appropriately set in the source.