### PR TITLE
Fix some typos in EventQueue and JobStarter.

### DIFF
--- a/src/main/java/com/streamwork/ch02/engine/EventQueue.java
+++ b/src/main/java/com/streamwork/ch02/engine/EventQueue.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import com.streamwork.ch02.api.Event;
 
 /**
- * This is the class for intemediate event queues between processes.
+ * This is the class for intermediate event queues between processes.
  */
 public class EventQueue extends ArrayBlockingQueue<Event> {
   private static final long serialVersionUID = 3673430816396878407L;

--- a/src/main/java/com/streamwork/ch02/engine/JobStarter.java
+++ b/src/main/java/com/streamwork/ch02/engine/JobStarter.java
@@ -47,7 +47,7 @@ public class JobStarter {
     for (Source source: job.getSources()) {
       SourceExecutor executor = new SourceExecutor(source);
       executorList.add(executor);
-      // For each source, traverse the the operations connected to it.
+      // For each source, traverse the operations connected to it.
       traverseComponent(source, executor);
     }
   }

--- a/src/main/java/com/streamwork/ch03/engine/EventQueue.java
+++ b/src/main/java/com/streamwork/ch03/engine/EventQueue.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import com.streamwork.ch03.api.Event;
 
 /**
- * This is the class for intemediate event queues between processes.
+ * This is the class for intermediate event queues between processes.
  */
 public class EventQueue extends ArrayBlockingQueue<Event> {
   private static final long serialVersionUID = -7123238470714210682L;

--- a/src/main/java/com/streamwork/ch03/engine/JobStarter.java
+++ b/src/main/java/com/streamwork/ch03/engine/JobStarter.java
@@ -48,7 +48,7 @@ public class JobStarter {
     for (Source source: job.getSources()) {
       SourceExecutor executor = new SourceExecutor(source);
       executorList.add(executor);
-      // For each source, traverse the the operations connected to it.
+      // For each source, traverse the operations connected to it.
       traverseComponent(source, executor);
     }
   }

--- a/src/main/java/com/streamwork/ch04/engine/EventQueue.java
+++ b/src/main/java/com/streamwork/ch04/engine/EventQueue.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import com.streamwork.ch04.api.Event;
 
 /**
- * This is the class for intemediate event queues between processes.
+ * This is the class for intermediate event queues between processes.
  */
 public class EventQueue extends ArrayBlockingQueue<Event> {
   private static final long serialVersionUID = 5299563454777716488L;

--- a/src/main/java/com/streamwork/ch04/engine/JobStarter.java
+++ b/src/main/java/com/streamwork/ch04/engine/JobStarter.java
@@ -53,7 +53,7 @@ public class JobStarter {
     for (Source source: job.getSources()) {
       SourceExecutor executor = new SourceExecutor(source);
       executorList.add(executor);
-      // For each source, traverse the the operations connected to it.
+      // For each source, traverse the operations connected to it.
       traverseComponent(source, executor);
     }
   }

--- a/src/main/java/com/streamwork/ch05/engine/EventQueue.java
+++ b/src/main/java/com/streamwork/ch05/engine/EventQueue.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import com.streamwork.ch05.api.Event;
 
 /**
- * This is the class for intemediate event queues between processes.
+ * This is the class for intermediate event queues between processes.
  */
 public class EventQueue extends ArrayBlockingQueue<Event> {
   private static final long serialVersionUID = 5299563454777716488L;

--- a/src/main/java/com/streamwork/ch05/engine/JobStarter.java
+++ b/src/main/java/com/streamwork/ch05/engine/JobStarter.java
@@ -53,7 +53,7 @@ public class JobStarter {
     for (Source source: job.getSources()) {
       SourceExecutor executor = new SourceExecutor(source);
       executorList.add(executor);
-      // For each source, traverse the the operations connected to it.
+      // For each source, traverse the operations connected to it.
       traverseComponent(source, executor);
     }
   }

--- a/src/main/java/com/streamwork/ch07/engine/EventQueue.java
+++ b/src/main/java/com/streamwork/ch07/engine/EventQueue.java
@@ -5,7 +5,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import com.streamwork.ch07.api.Event;
 
 /**
- * This is the class for intemediate event queues between processes.
+ * This is the class for intermediate event queues between processes.
  */
 public class EventQueue extends ArrayBlockingQueue<Event> {
   private static final long serialVersionUID = 5299563454777716488L;

--- a/src/main/java/com/streamwork/ch07/engine/JobStarter.java
+++ b/src/main/java/com/streamwork/ch07/engine/JobStarter.java
@@ -53,7 +53,7 @@ public class JobStarter {
     for (Source source: job.getSources()) {
       SourceExecutor executor = new SourceExecutor(source);
       executorList.add(executor);
-      // For each source, traverse the the operations connected to it.
+      // For each source, traverse the operations connected to it.
       traverseComponent(source, executor);
     }
   }

--- a/src/main/java/com/streamwork/ch08/engine/JobStarter.java
+++ b/src/main/java/com/streamwork/ch08/engine/JobStarter.java
@@ -54,7 +54,7 @@ public class JobStarter {
     for (Source source: job.getSources()) {
       SourceExecutor executor = new SourceExecutor(source);
       executorList.add(executor);
-      // For each source, traverse the the operations connected to it.
+      // For each source, traverse the operations connected to it.
       traverseComponent(source, executor);
     }
   }


### PR DESCRIPTION
Just encountered two typos in `EventQueue` and `JobStarter`. Thank you for the great book!